### PR TITLE
Update similarity threshold for duplicate detection in test case hand…

### DIFF
--- a/app/(dashboard)/projects/[id]/test-generation/[workItemId]/page.tsx
+++ b/app/(dashboard)/projects/[id]/test-generation/[workItemId]/page.tsx
@@ -257,7 +257,7 @@ export default function TestGenerationPage() {
             expectedResult: tc.expectedResult,
             preconditions: tc.preconditions,
           })),
-          similarityThreshold: 0.95, // 95% similarity threshold - more precise duplicate detection
+          similarityThreshold: 0.97, // 95% similarity threshold - more precise duplicate detection
           checkAgainstExistingOnly: true, // Ensure we only check against saved test cases
         }),
       });
@@ -330,7 +330,7 @@ export default function TestGenerationPage() {
             expectedResult: tc.expectedResult,
             preconditions: tc.preconditions,
           })),
-          similarityThreshold: 0.95, // 95% similarity threshold - more precise duplicate detection
+          similarityThreshold: 0.97, // 95% similarity threshold - more precise duplicate detection
           checkAgainstExistingOnly: true,
         }),
       });

--- a/app/api/ai/test-cases/check-duplicates/route.ts
+++ b/app/api/ai/test-cases/check-duplicates/route.ts
@@ -28,7 +28,7 @@ interface DuplicateCheckRequest {
 export async function POST(request: NextRequest) {
   try {
     const body: DuplicateCheckRequest = await request.json();
-    const { projectId, testCases, similarityThreshold = 0.95, checkAgainstExistingOnly = true } = body;
+    const { projectId, testCases, similarityThreshold = 0.97, checkAgainstExistingOnly = true } = body;
 
     if (!projectId || !testCases || !Array.isArray(testCases)) {
       return NextResponse.json(

--- a/lib/embedding-service.ts
+++ b/lib/embedding-service.ts
@@ -310,7 +310,7 @@ export class EmbeddingService {
   async checkTestCasesForDuplicates(
     testCases: (TestCase | Partial<TestCase>)[],
     projectId?: string,
-    similarityThreshold: number = 0.95,
+    similarityThreshold: number = 0.97,
     checkAgainstExistingOnly: boolean = true
   ): Promise<Array<{
     testCase: TestCase | Partial<TestCase>;


### PR DESCRIPTION
…ling

- Increased the default similarity threshold from 0.95 to 0.97 in the TestGenerationPage, API route, and EmbeddingService to enhance duplicate detection accuracy.
- Ensured consistency across components by aligning the threshold value in related functions.